### PR TITLE
chore(ci): Ubuntu 22.04に更新

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -28,26 +28,26 @@ jobs:
           -
             docker_image_registry: 'ghcr.io'
             docker_cache_registry: 'ghcr.io'
-            base_image: 'ubuntu:20.04'
-            base_runtime_image: 'ubuntu:20.04'
+            base_image: 'ubuntu:22.04'
+            base_runtime_image: 'ubuntu:22.04'
             image_variant_name: 'ubuntu'
           -
             docker_image_registry: 'ghcr.io'
             docker_cache_registry: 'ghcr.io'
-            base_image: 'ubuntu:20.04'
-            base_runtime_image: 'nvcr.io/nvidia/driver:510-signed-ubuntu20.04'
+            base_image: 'ubuntu:22.04'
+            base_runtime_image: 'nvcr.io/nvidia/driver:510-signed-ubuntu22.04'
             image_variant_name: 'nvidia'
           -
             docker_image_registry: 'docker.io'
             docker_cache_registry: 'ghcr.io'
-            base_image: 'ubuntu:20.04'
-            base_runtime_image: 'ubuntu:20.04'
+            base_image: 'ubuntu:22.04'
+            base_runtime_image: 'ubuntu:22.04'
             image_variant_name: 'ubuntu'
           -
             docker_image_registry: 'docker.io'
             docker_cache_registry: 'ghcr.io'
-            base_image: 'ubuntu:20.04'
-            base_runtime_image: 'nvcr.io/nvidia/driver:510-signed-ubuntu20.04'
+            base_image: 'ubuntu:22.04'
+            base_runtime_image: 'nvcr.io/nvidia/driver:510-signed-ubuntu22.04'
             image_variant_name: 'nvidia'
 
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
       matrix:
         include:
           -
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-22.04'
             sed: 'sed'
 
     runs-on: ${{ matrix.os }}
@@ -69,7 +69,7 @@ jobs:
       matrix:
         include:
           -
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-22.04'
             artifact_name: matvtool
             asset_name: matvtool-linux-amd64
             sed: 'sed'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4
@@ -41,7 +41,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: 'ubuntu-20.04'
+          # TODO: Ubuntu 24.04を追加
           - os: 'ubuntu-22.04'
 
     runs-on: ${{ matrix.os }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# syntax=docker/dockerfile:1.6
-ARG BASE_IMAGE=ubuntu:20.04
+# syntax=docker/dockerfile:1
+ARG BASE_IMAGE=ubuntu:22.04
 ARG BASE_RUNTIME_IMAGE=${BASE_IMAGE}
 
 FROM ${BASE_IMAGE} AS python-env

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command line tool to handle a multi audio track video file.
 ## インストール
 
 基本的にFFmpegのラッパーです。別途FFmpegのインストールが必要です。
-FFmpeg 4.2（Ubuntu 20.04の標準バージョン）および4.4（Ubuntu 22.04の標準バージョン）をサポートしています。
+FFmpeg 4.4（Ubuntu 22.04の標準バージョン）をサポートしています。
 
 - <https://ffmpeg.org/download.html>
 


### PR DESCRIPTION
Ubuntu 20.04は2025年4月に標準サポートが終了したため、CIで使用するOSをUbuntu 22.04に更新します。

- https://github.com/actions/runner-images/issues/11101
