### PR TITLE
chore(ci): Windows 2022に更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
             asset_name: matvtool-linux-amd64
             sed: 'sed'
           -
-            os: 'windows-2019'
+            os: 'windows-2022'
             artifact_name: matvtool.exe
             asset_name: matvtool-windows-amd64.exe
             sed: 'sed'


### PR DESCRIPTION
Windows 2019は2025年6月にGitHub Actionsでのサポートが終了したため、CIで使用するOSをWindows 2022に更新します。

- https://github.com/actions/runner-images/issues/12045