### PR TITLE
chore(ci): macOS 14に更新

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,7 +79,7 @@ jobs:
             asset_name: matvtool-windows-amd64.exe
             sed: 'sed'
           -
-            os: 'macos-12'
+            os: 'macos-14'
             artifact_name: matvtool
             asset_name: matvtool-macos-amd64
             sed: 'gsed'


### PR DESCRIPTION
macOS 12は、2024年3月にGitHub Actionsでのサポートが終了しました。

- https://github.com/actions/runner-images/issues/10721

またmacOS 13は、直近の2025年10月から非推奨プロセスの開始が計画されています。

- https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down

このため、CIで使用するOSをmacOS 14に更新します。
