### PR TITLE
fix(ci): PythonパッケージのTrusted publishingに必要なid-token権限を追加

### DIFF
--- a/.github/workflows/_publish-release.yml
+++ b/.github/workflows/_publish-release.yml
@@ -15,8 +15,6 @@ on:
 
 permissions:
   contents: write
-  # NOTE: Trusted publishingに必要
-  id-token: write
 
 defaults:
   run:

--- a/.github/workflows/_release-pypi.yml
+++ b/.github/workflows/_release-pypi.yml
@@ -11,6 +11,8 @@ on:
 
 permissions:
   contents: read
+  # NOTE: Trusted publishingに必要
+  id-token: write
 
 defaults:
   run:


### PR DESCRIPTION
PythonパッケージのリリースCIに`id-token: write`権限を追加します。

publish時の以下のエラーが修正される見込みです。

```plain
Run uv publish --trusted-publishing always
Publishing 2 files to https://upload.pypi.org/legacy/
error: Failed to obtain token for trusted publishing
  Caused by: Environment variable ACTIONS_ID_TOKEN_REQUEST_TOKEN not set, is the `id-token: write` permission missing?
```