### PR TITLE
chore: ジョブ名をワークフロー名に合わせる

### DIFF
--- a/.github/workflows/_create-draft-release.yml
+++ b/.github/workflows/_create-draft-release.yml
@@ -17,7 +17,7 @@ defaults:
     shell: bash
 
 jobs:
-  create-release:
+  create-draft-release:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/_publish-release.yml
+++ b/.github/workflows/_publish-release.yml
@@ -21,7 +21,7 @@ defaults:
     shell: bash
 
 jobs:
-  create-release:
+  publish-release:
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
ジョブ名をワークフロー名に合わせます。

リリース公開ジョブの名前を変え忘れていたのが修正されます。