### PR TITLE
chore(ci): Docker Hubへのデプロイが終わるまでリリースの公開を待つ

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -101,6 +101,7 @@ jobs:
       - generate-version
       - create-draft-release
       - build-docker-ghcr
+      - build-docker-dockerhub
       - release-pypi
       - release-binary
     if: needs.generate-version.outputs.git_version != 'edge'


### PR DESCRIPTION
Docker Hubへのデプロイが終わるまでリリースの公開を待つようにします。