### PR TITLE
chore(ci): 失敗したリリースを公開する

### DIFF
--- a/.github/workflows/_create-draft-release.yml
+++ b/.github/workflows/_create-draft-release.yml
@@ -36,5 +36,5 @@ jobs:
 
             **Do not make manual changes until the process has finished.**
 
-            👉 You can track the progress here: [View GitHub Actions Run](https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID})
+            👉 You can track the progress here: [View GitHub Actions Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
           allowUpdates: false

--- a/.github/workflows/_publish-failed-release.yml
+++ b/.github/workflows/_publish-failed-release.yml
@@ -1,0 +1,48 @@
+# 失敗したリリースのDraftを解除して公開する
+name: Publish Failed Release
+
+on:
+  workflow_call:
+    inputs:
+      git_version:
+        description: 'Gitタグとしてのバージョン（v{version}）'
+        type: string
+        required: true
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  publish-failed-release:
+    runs-on: ubuntu-latest
+
+    steps:
+      # 失敗したリリースのDraftを解除して公開
+      - name: Publish Failed Release
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ inputs.git_version }}
+          commit: ${{ github.sha }}
+          draft: false
+          prerelease: true
+          body: |-
+            # ❌ Automated Release Failed
+
+            The automated release process has failed.
+
+            This release has been published to retain the tag and preserve release immutability.
+
+            **Do not use this version except for debugging purposes.**
+
+            **This release will be removed without prior notice.**
+
+            👉 You can check the error details here: [View GitHub Actions Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          allowUpdates: true
+          omitNameDuringUpdate: false
+          omitDraftDuringUpdate: false
+          omitPrereleaseDuringUpdate: false
+          omitBodyDuringUpdate: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,3 +110,20 @@ jobs:
     with:
       git_version: ${{ needs.generate-version.outputs.git_version }}
       is_latest: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.is_latest == 'true' }}
+
+  # 失敗したリリースを公開する
+  publish-failed-release:
+    needs:
+      - generate-version
+      - create-draft-release
+      - build-docker-ghcr
+      - build-docker-dockerhub
+      - release-pypi
+      - release-binary
+      - publish-release
+    if: needs.generate-version.outputs.git_version != 'edge' && failure()
+    permissions:
+      contents: write
+    uses: ./.github/workflows/_publish-failed-release.yml
+    with:
+      git_version: ${{ needs.generate-version.outputs.git_version }}


### PR DESCRIPTION
失敗したリリースに紐づくGitタグが作成されず、
Docker Hubなどのデプロイ先にだけバージョンが存在する状況を避けるため、
リリースが失敗したときにリリースを公開するようにします。