### PR TITLE
chore: VideoSlicerから使われていないKeyFrameParserへの依存を削除

### DIFF
--- a/aoirint_matvtool/command/slice.py
+++ b/aoirint_matvtool/command/slice.py
@@ -7,7 +7,6 @@ from ..progress_handler.base import ProgressHandler
 from ..progress_handler.plain import ProgressHandlerPlain
 from ..progress_handler.tqdm import ProgressHandlerTqdm
 from ..video_utility.fps_parser import FpsParser
-from ..video_utility.key_frame_parser import KeyFrameParser
 from ..video_utility.video_slicer import VideoSlicer, VideoSlicerProgress
 
 
@@ -28,14 +27,8 @@ async def execute_slice_cli(
         ffprobe_path=ffprobe_path,
     )
 
-    key_frame_parser = KeyFrameParser(
-        fps_parser=fps_parser,
-        ffprobe_path=ffprobe_path,
-    )
-
     video_slicer = VideoSlicer(
         fps_parser=fps_parser,
-        key_frame_parser=key_frame_parser,
         ffmpeg_path=ffmpeg_path,
     )
 

--- a/aoirint_matvtool/video_utility/video_slicer.py
+++ b/aoirint_matvtool/video_utility/video_slicer.py
@@ -15,7 +15,6 @@ from ..util import (
 )
 from ..utility.async_subprocess_helper import wait_process
 from ..video_utility.fps_parser import FpsParser
-from .key_frame_parser import KeyFrameParser
 
 logger = getLogger(__name__)
 
@@ -31,11 +30,9 @@ class VideoSlicer:
     def __init__(
         self,
         fps_parser: FpsParser,
-        key_frame_parser: KeyFrameParser,
         ffmpeg_path: str,
     ) -> None:
         self._fps_parser = fps_parser
-        self._key_frame_parser = key_frame_parser
         self._ffmpeg_path = ffmpeg_path
 
     async def slice_video(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,11 +86,9 @@ def key_frame_parser(
 @pytest.fixture
 def video_slicer(
     fps_parser: FpsParser,
-    key_frame_parser: KeyFrameParser,
     ffmpeg_path: str,
 ) -> VideoSlicer:
     return VideoSlicer(
         fps_parser=fps_parser,
-        key_frame_parser=key_frame_parser,
         ffmpeg_path=ffmpeg_path,
     )


### PR DESCRIPTION
VideoSlicerから使われていないKeyFrameParserへの依存を削除します。

