### PR TITLE
fix: モジュール実行時の関数を同期関数に変更

### DIFF
--- a/aoirint_matvtool/__main__.py
+++ b/aoirint_matvtool/__main__.py
@@ -1,6 +1,4 @@
-import asyncio
-
 from .cli import main
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()

--- a/aoirint_matvtool/cli.py
+++ b/aoirint_matvtool/cli.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from argparse import ArgumentParser, Namespace
 from asyncio import iscoroutinefunction
@@ -86,7 +87,7 @@ async def add_arguments_main_cli(parser: ArgumentParser) -> None:
     await add_arguments_select_audio_cli(parser=parser_select_audio)
 
 
-async def main() -> None:
+async def main_async() -> None:
     parser = ArgumentParser()
     await add_arguments_main_cli(parser=parser)
 
@@ -95,3 +96,7 @@ async def main() -> None:
         parser=parser,
         args=args,
     )
+
+
+def main() -> None:
+    asyncio.run(main_async())

--- a/binary_entrypoint.py
+++ b/binary_entrypoint.py
@@ -2,9 +2,7 @@
 PyInstallerでバイナリビルドするときのエントリーポイント
 """
 
-import asyncio
-
 from aoirint_matvtool.cli import main
 
 if __name__ == "__main__":
-    asyncio.run(main())
+    main()


### PR DESCRIPTION
モジュール実行時の関数を同期関数に変更します。

以下のエラーが修正される見込みです。

```plain
<coroutine object main at 0x7f1576317ca0>
sys:1: RuntimeWarning: coroutine 'main' was never awaited
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

## 関連Issue

- close #106